### PR TITLE
Fix datetime error in supervisord and use new get_auth_hs() function

### DIFF
--- a/tethysapp/hydroshare_gis/controllers.py
+++ b/tethysapp/hydroshare_gis/controllers.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
-#from utilities import get_oauth_hs
 from tethys_services.backends.hs_restclient_helper import get_oauth_hs
 
 @login_required()

--- a/tethysapp/hydroshare_gis/controllers.py
+++ b/tethysapp/hydroshare_gis/controllers.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
-from utilities import get_oauth_hs
-
+#from utilities import get_oauth_hs
+from tethys_services.backends.hs_restclient_helper import get_oauth_hs
 
 @login_required()
 def home(request):

--- a/tethysapp/hydroshare_gis/controllers_ajax.py
+++ b/tethysapp/hydroshare_gis/controllers_ajax.py
@@ -1,9 +1,10 @@
 from django.http import JsonResponse, Http404, HttpResponse
 
-from utilities import get_hs_res_object, get_oauth_hs, get_hs_res_list, get_geoserver_url, \
+from utilities import get_hs_res_object, get_hs_res_list, get_geoserver_url, \
     process_local_file, save_new_project, save_project, generate_attribute_table, delete_tempfiles, \
     get_features_on_click, get_res_files_list, get_res_layers_from_db, get_res_layer_obj_from_generic_file, \
     get_file_mime_type, validate_res_request, get_generic_file_layer_from_db
+from tethys_services.backends.hs_restclient_helper import get_oauth_hs
 
 from model import ResourceLayersCount
 

--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -25,22 +25,6 @@ workspace_id = None
 spatial_dataset_engine = None
 currently_testing = False
 
-def get_oauth_hs(request):
-    hs = None
-    hs_hostname = 'www.hydroshare.org'
-    try:
-        client_id = getattr(settings, 'SOCIAL_AUTH_HYDROSHARE_KEY', 'None')
-        client_secret = getattr(settings, 'SOCIAL_AUTH_HYDROSHARE_SECRET', 'None')
-        token = request.user.social_auth.get(provider='hydroshare').extra_data['token_dict']
-        auth = hs_r.HydroShareAuthOAuth2(client_id, client_secret, token=token)
-        hs = hs_r.HydroShare(auth=auth, hostname=hs_hostname)
-    except ObjectDoesNotExist:
-        if '127.0.0.1' in request.get_host() or 'localhost' in request.get_host():
-            auth = hs_r.HydroShareAuthBasic(username='test', password='test')
-            hs = hs_r.HydroShare(auth=auth, hostname=hs_hostname)
-    return hs
-
-
 def get_json_response(response_type, message):
     return JsonResponse({response_type: message})
 
@@ -1145,9 +1129,7 @@ def get_res_mod_date(hs, res_id):
 
 
 def res_has_been_updated(db_date, res_date):
-    #db_date_obj = datetime.strptime(db_date.split('+')[0], '%Y-%m-%dT%X.%f')
     db_date_obj = datetime.strptime(db_date.split('+')[0], '%Y-%m-%dT%H:%M:%S.%f')
-    #res_date_obj = datetime.strptime(res_date.split('+')[0], '%Y-%m-%dT%X.%f')
     res_date_obj = datetime.strptime(res_date.split('+')[0], '%Y-%m-%dT%H:%M:%S.%f')
     
     if db_date_obj < res_date_obj:

--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -1145,8 +1145,11 @@ def get_res_mod_date(hs, res_id):
 
 
 def res_has_been_updated(db_date, res_date):
-    db_date_obj = datetime.strptime(db_date.split('+')[0], '%Y-%m-%dT%X.%f')
-    res_date_obj = datetime.strptime(res_date.split('+')[0], '%Y-%m-%dT%X.%f')
+    #db_date_obj = datetime.strptime(db_date.split('+')[0], '%Y-%m-%dT%X.%f')
+    db_date_obj = datetime.strptime(db_date.split('+')[0], '%Y-%m-%dT%H:%M:%S.%f')
+    #res_date_obj = datetime.strptime(res_date.split('+')[0], '%Y-%m-%dT%X.%f')
+    res_date_obj = datetime.strptime(res_date.split('+')[0], '%Y-%m-%dT%H:%M:%S.%f')
+    
     if db_date_obj < res_date_obj:
         return True
 


### PR DESCRIPTION
@shawncrawley 
1) change to use locale-independent datetime string to avoid parsing error when supervisord is enabled

2) change to use new get_auth_hs() function, which can detect the HydroShare instance (www, beta or others...)  from which the user logged in, and create hs obj against that hydroshare instance.

I would like to put the new get_auth_hs() function in tethys source code (tehtys_services/backends/hs_restclient_helper.py), so other apps can reference and use it instead of duplicating this function in each app.