### PR TITLE
purge geoserver workspace on first time init_stores

### DIFF
--- a/tethysapp/hydroshare_gis/init_stores.py
+++ b/tethysapp/hydroshare_gis/init_stores.py
@@ -1,4 +1,12 @@
 from .model import engine, Base
+from tethys_sdk.services import get_spatial_dataset_engine
+from utilities import get_workspace
 
 def init_hydroshare_gis_layers_db(first_time):
     Base.metadata.create_all(engine)
+
+    if first_time:
+        spatial_dataset_engine = get_spatial_dataset_engine(name='default')
+        spatial_dataset_engine.delete_workspace(workspace_id=get_workspace(),
+                                                purge=True,
+                                                recurse=True)

--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -1,8 +1,6 @@
 from django.http import JsonResponse
-from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
 from tethys_sdk.services import get_spatial_dataset_engine
-from django.core.exceptions import ObjectDoesNotExist
 from model import Layer
 
 import hs_restclient as hs_r
@@ -1273,7 +1271,7 @@ def get_generic_file_layer_from_db(hs, res_id, res_fname, file_index, username):
 
         if flag_reload_layer:
             Layer.remove_layer_by_res_id_and_res_fname(res_id, res_fname)
-            remove_layer_from_geoserver(res_id)
+            remove_layer_from_geoserver(res_id, file_index)
             generic_file_layer = get_res_layer_obj_from_generic_file(hs, res_id, res_fname, username, file_index)
         else:
             generic_file_layer = {


### PR DESCRIPTION
If the persistent store database is refreshed (emptied), then all of the corresponding geoserver layers should also be removed. This feature has been added in this PR.