### PR TITLE
62 remove some global vars

### DIFF
--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -23,8 +23,6 @@ from logging import getLogger
 
 
 logger = getLogger('django')
-#workspace_id = None
-#spatial_dataset_engine = None
 currently_testing = False
 
 def get_json_response(response_type, message):
@@ -156,8 +154,7 @@ def zip_files(res_files, zip_path):
 
 
 def return_spatial_dataset_engine():
-    #global spatial_dataset_engine
-    #if spatial_dataset_engine is None:
+
     spatial_dataset_engine = get_spatial_dataset_engine(name='default')
 
     return spatial_dataset_engine
@@ -745,8 +742,7 @@ def get_hs_res_list(hs):
 
 
 def get_workspace():
-    #global workspace_id
-    #if workspace_id is None:
+
     if 'apps.hydroshare' in gethostname():
         workspace_id = 'hydroshare_gis'
     else:

--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -23,8 +23,8 @@ from logging import getLogger
 
 
 logger = getLogger('django')
-workspace_id = None
-spatial_dataset_engine = None
+#workspace_id = None
+#spatial_dataset_engine = None
 currently_testing = False
 
 def get_json_response(response_type, message):
@@ -156,9 +156,9 @@ def zip_files(res_files, zip_path):
 
 
 def return_spatial_dataset_engine():
-    global spatial_dataset_engine
-    if spatial_dataset_engine is None:
-        spatial_dataset_engine = get_spatial_dataset_engine(name='default')
+    #global spatial_dataset_engine
+    #if spatial_dataset_engine is None:
+    spatial_dataset_engine = get_spatial_dataset_engine(name='default')
 
     return spatial_dataset_engine
 
@@ -745,12 +745,12 @@ def get_hs_res_list(hs):
 
 
 def get_workspace():
-    global workspace_id
-    if workspace_id is None:
-        if 'apps.hydroshare' in gethostname():
-            workspace_id = 'hydroshare_gis'
-        else:
-            workspace_id = 'hydroshare_gis_testing'
+    #global workspace_id
+    #if workspace_id is None:
+    if 'apps.hydroshare' in gethostname():
+        workspace_id = 'hydroshare_gis'
+    else:
+        workspace_id = 'hydroshare_gis_testing'
 
     return workspace_id
 
@@ -1715,5 +1715,6 @@ def get_hs_auth_obj(request):
 
 
 def get_geoserver_store_id(res_id, file_index=None):
-    return 'gis_{res_id}{flag}'.format(res_id=res_id,
-                                       flag='_{0}'.format(file_index) if file_index else '')
+    return '{gis}_{res_id}{flag}'.format(gis=get_workspace(),
+                                         res_id=res_id,
+                                         flag='_{0}'.format(file_index) if file_index else '')


### PR DESCRIPTION
This pr needs careful review to make sure it does not break other features.

1) remove global var spatial_dataset_engine: it made gis app keep using the very first value set to geoserver url on tethys admin page, later changes can not become effective unless a hard restart on django server.

2) remove global var workspace_id: I dont think we need this global var as it may have side-effect as above.

3) make store_id different between apps server and other servers(appsdev):  after making apps server talk to appsdev geoserver, I tried to view a raster res (say res_id=ABC123) on apps, it said "load successfully" but the raster didnt show up. This was because on appsdev geoserver there was already a raster file with store_id "gis_ABC123". So although two layers are already under different workspaces, their store_ids should be different as well. Or say: store_id should be globally unique across all data in geoserver