### PR TITLE
Support composite resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ $ git pull
 ```
 Restart the Apache Server:
 See: http://docs.tethysplatform.org/en/latest/production/installation.html#enable-site-and-restart-apache
+
+##Fin

--- a/tethysapp/hydroshare_gis/public/js/main.js
+++ b/tethysapp/hydroshare_gis/public/js/main.js
@@ -1190,7 +1190,7 @@
             showMainLoadAnim();
             if (params.res_fname) {
                 addGenericResFiles(params.res_id, params.res_fname);
-            } else if (["GenericResource", "ScriptResource", "CompositeResource"].indexOf(params.resType) !== -1) {
+            } else if (["GenericResource", "ScriptResource", "CompositeResource"].indexOf(params.res_type) !== -1) {
                 addGenericResFiles(params.res_id);
             } else {
                 addNonGenericRes(params.res_id, params.res_type, null, true, null);

--- a/tethysapp/hydroshare_gis/public/js/main.js
+++ b/tethysapp/hydroshare_gis/public/js/main.js
@@ -1190,7 +1190,7 @@
             showMainLoadAnim();
             if (params.res_fname) {
                 addGenericResFiles(params.res_id, params.res_fname);
-            } else if (params.res_type === "GenericResource" || params.res_type === "ScriptResource") {
+            } else if (["GenericResource", "ScriptResource", "CompositeResource"].indexOf(params.resType) !== -1) {
                 addGenericResFiles(params.res_id);
             } else {
                 addNonGenericRes(params.res_id, params.res_type, null, true, null);
@@ -2154,7 +2154,7 @@
         showMainLoadAnim();
         $modalAddRes.modal('hide');
 
-        if (resType === "GenericResource" || resType === "ScriptResource") {
+        if (["GenericResource", "ScriptResource", "CompositeResource"].indexOf(resType) !== -1) {
             addGenericResFiles(resId);
         } else {
             addNonGenericRes(resId, resType, resTitle, true, null);

--- a/tethysapp/hydroshare_gis/templates/hydroshare_gis/base.html
+++ b/tethysapp/hydroshare_gis/templates/hydroshare_gis/base.html
@@ -90,5 +90,5 @@
     <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
     <script src="{% static 'hydroshare_gis/vendor/spectrum/spectrum.js' %}"></script>
     <script src="{% static 'hydroshare_gis/vendor/openlayers/v3.14.2/ol.js' %}"></script>
-    <script src="{% static 'hydroshare_gis/js/main.js' %}?v=1.00"></script>
+    <script src="{% static 'hydroshare_gis/js/main.js' %}?v=1.01"></script>
 {% endblock %}

--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -708,7 +708,10 @@ def get_hs_res_list(hs):
     res_list = []
 
     try:
-        valid_res_types = ['GenericResource', 'GeographicFeatureResource', 'RasterResource', 'RefTimeSeriesResource', 'TimeSeriesResource', 'ScriptResource']
+        valid_res_types = [
+            'GenericResource', 'GeographicFeatureResource', 'RasterResource', 'RefTimeSeriesResource', 'TimeSeriesResource', 
+            'ScriptResource', 'CompositeResource'
+        ]
         for res in hs.getResourceList(types=valid_res_types):
             res_id = res['resource_id']
             # This code calculates the cummulative files size of each resource. Comment out to improve performance.

--- a/tethysapp/hydroshare_gis/utilities.py
+++ b/tethysapp/hydroshare_gis/utilities.py
@@ -1124,6 +1124,7 @@ def get_res_files_list(hs, res_id):
     full_name_list = []
     name_list = []
     size_list = []
+    ignore_exts = ['.vrt']
     req_shp_file_exts = ['.shp', '.prj', '.shx', '.dbf']
     all_shp_file_exts = req_shp_file_exts + ['.sbn', '.sbx', '.cpg', '.xml']
     rem_shp_file_exts = all_shp_file_exts[:]
@@ -1162,6 +1163,8 @@ def get_res_files_list(hs, res_id):
 
                         if ext != '.shp':
                             continue
+                elif ext in ignore_exts:
+                    continue
 
                 name_list.append(basename)
                 size_list.append(size)


### PR DESCRIPTION
This PR modifies HydroShare GIS to support Composite Resources. It does so by treating Composite Resources as Generic Resources, as it was found that they behave essentially the same behind the scenes. 

There are still shortcomings with how HydroShare GIS handles Generic Resources, some of which may be even more prevalent with Composite Resources. For example, VRT files are now ignored (and should have been before). This was a quick fix to a bug that would have been showing up with Generic Resources as well. As far as the Generic Resources go, it is probably fine to ignore VRT files. However, it is more likely that a Composite Resource would contain a VRT that is actually designating a multi-tif composition, in which case HydroShare GIS will fall short of the expected behavior. For now, I'm assuming that case will still be few and far between. The bug can be addressed when the situation arises.